### PR TITLE
always quote sqlite identifiers (same as sql server provider)

### DIFF
--- a/src/Migrator.Providers/Impl/SQLite/SQLiteDialect.cs
+++ b/src/Migrator.Providers/Impl/SQLite/SQLiteDialect.cs
@@ -37,8 +37,14 @@ namespace Migrator.Providers.SQLite
             RegisterColumnType(DbType.Guid, "UNIQUEIDENTIFIER");
 
             RegisterProperty(ColumnProperty.Identity, "AUTOINCREMENT");
-            RegisterProperty(ColumnProperty.CaseSensitive, "COLLATE NOCASE"); 
+            RegisterProperty(ColumnProperty.CaseSensitive, "COLLATE NOCASE");
         }
+
+		public override bool ColumnNameNeedsQuote => true;
+
+		public override bool TableNameNeedsQuote => true;
+
+		public override string QuoteTemplate => "\"{0}\"";
 
         public override string Default(object defaultValue)
         {


### PR DESCRIPTION
sqlite provider had no escaping implemented. Easy way is just escape all identifiers, as done in the sql server provider. 