### PR TITLE
Fix NullReferenceException with Netstandard 2.0

### DIFF
--- a/src/Migrator/MigrationLoader.cs
+++ b/src/Migrator/MigrationLoader.cs
@@ -131,11 +131,7 @@ namespace Migrator
 		/// <returns>Version number sepcified in the attribute</returns>
 		public static long GetMigrationVersion(Type t)
 		{
-#if NETSTANDARD
-			var attrib = t.GetType().GetTypeInfo().GetCustomAttribute<MigrationAttribute>();
-#else
 			var attrib = (MigrationAttribute) Attribute.GetCustomAttribute(t, typeof (MigrationAttribute));
-#endif
 			return attrib.Version;
 		}
 


### PR DESCRIPTION
With Netstandard 2 there was a nullef exception. The api used is available for netstandard 2, so i removed the #if. works for me with sqlite.