### PR TITLE
Throw if GetColumnContentSize column is not of type string.

### DIFF
--- a/src/Migrator.Tests/Providers/PostgreSQL/PostgreSQLTransformationProvider_GetColumnContentSizeTests.cs
+++ b/src/Migrator.Tests/Providers/PostgreSQL/PostgreSQLTransformationProvider_GetColumnContentSizeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using DotNetProjects.Migrator.Framework;
 using NUnit.Framework;
@@ -9,11 +10,10 @@ namespace Migrator.Tests.Providers.PostgreSQL;
 public class PostgreSQLTransformationProvider_GetColumnContentSizeTests : PostgreSQLTransformationProviderTestBase
 {
     [Test]
-    public void GetColumnContentSize_DefaultValues_Succeeds()
+    public void GetColumnContentSize_UseStringColumn_MaxContentLengthIsCorrect()
     {
         // Arrange
         const string testTableName = "testtable";
-
         const string stringColumnName = "stringcolumn";
 
         Provider.AddTable(testTableName,
@@ -29,5 +29,23 @@ public class PostgreSQLTransformationProvider_GetColumnContentSizeTests : Postgr
 
         // Assert
         Assert.That(columnContentSize, Is.EqualTo(4444));
+    }
+
+    [Test]
+    public void GetColumnContentSize_UseOnNonStringColumn_ThrowsSpeakingException()
+    {
+        // Arrange
+        const string testTableName = "testtable";
+        const string stringColumnName = "nonstringcolumn";
+
+        Provider.AddTable(testTableName,
+            new Column(stringColumnName, DbType.Int32)
+        );
+
+        // Act
+        var exception = Assert.Throws<Exception>(() => Provider.GetColumnContentSize(testTableName, stringColumnName));
+
+        // Assert
+        Assert.That(exception.Message, Does.Contain("is not of type string"));
     }
 }

--- a/src/Migrator/Providers/Impl/PostgreSQL/PostgreSQLTransformationProvider.cs
+++ b/src/Migrator/Providers/Impl/PostgreSQL/PostgreSQLTransformationProvider.cs
@@ -251,6 +251,23 @@ WHERE  lower(tablenm) = lower('{0}')
 
     public override int GetColumnContentSize(string table, string columnName)
     {
+        if (!TableExists(table))
+        {
+            throw new Exception($"Table '{table}' not found.");
+        }
+
+        if (!ColumnExists(table, columnName, true))
+        {
+            throw new Exception($"Column '{columnName}' does not exist");
+        }
+
+        var column = GetColumnByName(table, columnName);
+
+        if (column.MigratorDbType != MigratorDbType.String)
+        {
+            throw new Exception($"Column '{columnName}' in table {table} is not of type string");
+        }
+
         var result = ExecuteScalar($"SELECT MAX(LENGTH({QuoteColumnNameIfRequired(columnName)})) FROM {QuoteTableNameIfRequired(table)}");
 
         if (result == DBNull.Value)


### PR DESCRIPTION
Would throw in any way but a message that could be misunderstood.